### PR TITLE
fix: make the project installable, and close arbitrary file read and two DoS paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ ROBROWSER_PATH=../roBrowserLegacy
 # Serves AI-upscaled textures/sprites from a pre-built disk cache.
 # When enabled, asset requests are intercepted and served from the cache
 # before falling through to GRF lookup. Zero overhead when disabled.
-# Install: npm install @chicowall/robrowser-esrgan
+# Install: npm install github:FranciscoWallison/robrowser-esrgan
 # Populate cache: python tools/esrgan_pipeline/orchestrate.py
 #ESRGAN_ENABLED=true
 #ESRGAN_CACHE_DIR=./upscaled_cache

--- a/README-pt-br.md
+++ b/README-pt-br.md
@@ -141,10 +141,10 @@ Veja [Variaveis de Ambiente](#variaveis-de-ambiente) para todas as opcoes.
 
 ```bash
 # Preparacao completa (valida config, gera mapeamento de paths, constroi indice)
-npm run prepare
+npm run setup
 
 # Preparacao rapida (pula validacao profunda de encoding)
-npm run prepare:quick
+npm run setup:quick
 ```
 
 ### 5. Executar o Servidor
@@ -423,8 +423,8 @@ curl -X POST http://localhost:3338/search \
 |--------|-----------|
 | `npm start` | Iniciar o servidor (desenvolvimento, detalhado) |
 | `npm run start:prod` | Iniciar o servidor (producao, logs minimos) |
-| `npm run prepare` | Otimizacao completa pre-inicializacao |
-| `npm run prepare:quick` | Pre-inicializacao rapida (pula validacao profunda) |
+| `npm run setup` | Otimizacao completa pre-inicializacao |
+| `npm run setup:quick` | Pre-inicializacao rapida (pula validacao profunda) |
 | `npm run doctor` | Executar validacao de diagnostico |
 | `npm run doctor:deep` | Validacao profunda com verificacao de encoding |
 | `npm run debug-grf` | Debug do carregamento de arquivos GRF |
@@ -539,7 +539,7 @@ O servidor registra arquivos ausentes em `logs/missing-files.log`. Verifique:
 1. Verifique hit rate do cache: `curl http://localhost:3338/api/cache-stats`
 2. Aumente tamanho do cache via `.env` (veja [Variaveis de Ambiente](#variaveis-de-ambiente))
 3. Ative aquecimento de cache: `CACHE_WARM_UP=true`
-4. Execute `npm run prepare` para pre-construir indices
+4. Execute `npm run setup` para pre-construir indices
 
 ### Proxy WebSocket Nao Funciona
 
@@ -557,7 +557,7 @@ O servidor registra arquivos ausentes em `logs/missing-files.log`. Verifique:
 | GRF incompativel | Reempacote com GRF Builder (versao 0x200, sem DES) |
 | DATA.INI ausente | Crie `resources/DATA.INI` |
 | Problemas de encoding | Execute `npm run convert:encoding` |
-| Acesso lento a arquivos | Aumente cache, ative aquecimento, execute `npm run prepare` |
+| Acesso lento a arquivos | Aumente cache, ative aquecimento, execute `npm run setup` |
 | Conexao WS proxy recusada | Verifique se rAthena esta rodando, confira portas |
 | Arquivos estaticos nao servidos | Confira se `ROBROWSER_PATH` aponta para o diretorio do roBrowserLegacy |
 

--- a/README.md
+++ b/README.md
@@ -144,10 +144,10 @@ See [Environment Variables](#environment-variables) for all options.
 
 ```bash
 # Full preparation (validates config, generates path mapping, builds index)
-npm run prepare
+npm run setup
 
 # Quick preparation (skips deep encoding validation)
-npm run prepare:quick
+npm run setup:quick
 ```
 
 ### 5. Run the Server
@@ -538,8 +538,8 @@ curl -X POST http://localhost:3338/search \
 |--------|-------------|
 | `npm start` | Start the server (development, verbose) |
 | `npm run start:prod` | Start the server (production, minimal logging) |
-| `npm run prepare` | Full pre-startup optimization |
-| `npm run prepare:quick` | Quick pre-startup (skip deep validation) |
+| `npm run setup` | Full pre-startup optimization |
+| `npm run setup:quick` | Quick pre-startup (skip deep validation) |
 | `npm run doctor` | Run diagnostic validation |
 | `npm run doctor:deep` | Deep validation with encoding check |
 | `npm run debug-grf` | Debug GRF file loading |
@@ -654,7 +654,7 @@ The server logs missing files to `logs/missing-files.log`. Check:
 1. Check cache hit rate: `curl http://localhost:3338/api/cache-stats`
 2. Increase cache size via `.env` (see [Environment Variables](#environment-variables))
 3. Enable cache warm-up: `CACHE_WARM_UP=true`
-4. Run `npm run prepare` to pre-build indexes
+4. Run `npm run setup` to pre-build indexes
 
 ### WebSocket Proxy Not Working
 
@@ -672,7 +672,7 @@ The server logs missing files to `logs/missing-files.log`. Check:
 | Incompatible GRF | Repack with GRF Builder (version 0x200, no DES) |
 | Missing DATA.INI | Create `resources/DATA.INI` |
 | Encoding issues | Run `npm run convert:encoding` |
-| Slow file access | Increase cache size, enable warm-up, run `npm run prepare` |
+| Slow file access | Increase cache size, enable warm-up, run `npm run setup` |
 | WS proxy connection refused | Check rAthena is running, verify target ports |
 | Static files not served | Check `ROBROWSER_PATH` points to roBrowserLegacy directory |
 

--- a/index.js
+++ b/index.js
@@ -98,21 +98,22 @@ async function startServer() {
   // Plugin: @chicowall/robrowser-esrgan (optional dependency, installed from GitHub)
   let esrganInstance = null;
   if (ESRGAN_ENABLED) {
-    let createEsrganMiddleware = null;
+    // Resolve before requiring: require.resolve() does not execute the module, so a
+    // MODULE_NOT_FOUND here can only mean the plugin itself is absent. Loading it is
+    // then left unguarded on purpose -- a broken install must surface as a real error,
+    // not be silently downgraded to "not installed".
+    let pluginPath = null;
     try {
-      createEsrganMiddleware = require('@chicowall/robrowser-esrgan');
+      pluginPath = require.resolve('@chicowall/robrowser-esrgan');
     } catch (err) {
-      // Only swallow "the plugin itself is absent". A MODULE_NOT_FOUND coming from
-      // inside the plugin means a broken install, and must not be reported as "not installed".
-      const pluginAbsent =
-        err.code === 'MODULE_NOT_FOUND' && err.message.includes('@chicowall/robrowser-esrgan');
-      if (!pluginAbsent) throw err;
+      if (err.code !== 'MODULE_NOT_FOUND') throw err;
       logger.warn('ESRGAN_ENABLED is set but @chicowall/robrowser-esrgan is not installed.');
       logger.warn('Install it with: npm install github:FranciscoWallison/robrowser-esrgan');
       logger.warn('Continuing without upscaling.\n');
     }
 
-    if (createEsrganMiddleware) {
+    if (pluginPath) {
+      const createEsrganMiddleware = require(pluginPath);
       const cachePath = path.resolve(__dirname, ESRGAN_CACHE_DIR);
       esrganInstance = await createEsrganMiddleware({ cacheDir: cachePath, logger });
       app.use(esrganInstance.middleware);

--- a/index.js
+++ b/index.js
@@ -95,13 +95,28 @@ async function startServer() {
   }
 
   // ESRGAN upscaling middleware - serves upscaled assets from disk cache
-  // Plugin: @chicowall/robrowser-esrgan (external package)
+  // Plugin: @chicowall/robrowser-esrgan (optional dependency, installed from GitHub)
   let esrganInstance = null;
   if (ESRGAN_ENABLED) {
-    const createEsrganMiddleware = require('@chicowall/robrowser-esrgan');
-    const cachePath = path.resolve(__dirname, ESRGAN_CACHE_DIR);
-    esrganInstance = await createEsrganMiddleware({ cacheDir: cachePath, logger });
-    app.use(esrganInstance.middleware);
+    let createEsrganMiddleware = null;
+    try {
+      createEsrganMiddleware = require('@chicowall/robrowser-esrgan');
+    } catch (err) {
+      // Only swallow "the plugin itself is absent". A MODULE_NOT_FOUND coming from
+      // inside the plugin means a broken install, and must not be reported as "not installed".
+      const pluginAbsent =
+        err.code === 'MODULE_NOT_FOUND' && err.message.includes('@chicowall/robrowser-esrgan');
+      if (!pluginAbsent) throw err;
+      logger.warn('ESRGAN_ENABLED is set but @chicowall/robrowser-esrgan is not installed.');
+      logger.warn('Install it with: npm install github:FranciscoWallison/robrowser-esrgan');
+      logger.warn('Continuing without upscaling.\n');
+    }
+
+    if (createEsrganMiddleware) {
+      const cachePath = path.resolve(__dirname, ESRGAN_CACHE_DIR);
+      esrganInstance = await createEsrganMiddleware({ cacheDir: cachePath, logger });
+      app.use(esrganInstance.middleware);
+    }
   }
 
   // Validation status endpoint (JSON for frontend)

--- a/index.js
+++ b/index.js
@@ -160,7 +160,10 @@ async function startServer() {
     // Handle Vite-style ?raw imports (must come before express.static)
     app.use(createRawImportMiddleware(roBrowserAbsPath));
 
-    app.use(express.static(roBrowserAbsPath));
+    // dotfiles: 'deny' keeps .git/ and .env out of reach. The doc root is the
+    // roBrowserLegacy checkout itself (the raw-import middleware above serves its
+    // src/ as ES modules), so without this the whole repository is downloadable.
+    app.use(express.static(roBrowserAbsPath, { dotfiles: 'deny' }));
   }
 
   // API routes (GRF file serving, search, etc.)

--- a/package.json
+++ b/package.json
@@ -21,12 +21,14 @@
 	"license": "GNU GPL V3",
 	"dependencies": {
 		"@chicowall/grf-loader": "^1.1.0",
-		"@chicowall/robrowser-esrgan": "file:../../robrowser-esrgan",
 		"compression": "^1.8.1",
 		"cors": "^2.8.5",
 		"dotenv": "^17.2.3",
 		"express": "^4.17.1",
 		"iconv-lite": "^0.7.1",
 		"ws": "^8.19.0"
+	},
+	"optionalDependencies": {
+		"@chicowall/robrowser-esrgan": "github:FranciscoWallison/robrowser-esrgan"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
 	"scripts": {
 		"start": "node index.js",
 		"start:prod": "node start-prod.js",
-		"prepare": "node prepare.js",
-		"prepare:quick": "node prepare.js --quick",
+		"setup": "node prepare.js",
+		"setup:quick": "node prepare.js --quick",
 		"doctor": "node doctor.js",
 		"doctor:deep": "node doctor.js --deep",
 		"debug-grf": "node debug-grf.js",

--- a/prepare.js
+++ b/prepare.js
@@ -9,8 +9,13 @@
  * 4. Optionally warms up cache
  *
  * Usage:
- *   npm run prepare          # Run all preparation steps
- *   npm run prepare -- --quick  # Quick mode (skip deep validation)
+ *   npm run setup            # Run all preparation steps
+ *   npm run setup:quick      # Quick mode (skip deep validation)
+ *
+ * Note: this is a manual command. It must NOT be named "prepare" in
+ * package.json -- npm treats that name as an install lifecycle hook and would
+ * run it on every "npm install", where the client files it checks for do not
+ * exist yet.
  */
 
 const fs = require('fs');

--- a/src/controllers/clientController.js
+++ b/src/controllers/clientController.js
@@ -20,6 +20,41 @@ function decodeMojibake(str) {
   }
 }
 
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..');
+
+/**
+ * Top-level directories the client is allowed to read from disk.
+ *
+ * These are the Ragnarok client asset trees (the same ones .gitignore excludes).
+ * The project root itself is NOT a document root: it also holds .env, .git/,
+ * logs/ and the server source, none of which may ever be reachable over HTTP.
+ */
+const SERVABLE_ROOTS = ['data', 'bgm', 'system', 'ai'];
+
+/**
+ * Resolve a client-supplied path inside `base`, or return null if it escapes.
+ *
+ * Rejects NUL bytes, absolute paths (which would make path.resolve discard the
+ * base entirely) and any sequence that climbs out of the base with "..".
+ */
+function resolveContained(base, requestPath) {
+  if (typeof requestPath !== 'string' || requestPath.length === 0) return null;
+  if (requestPath.includes('\0')) return null;
+
+  const resolved = path.resolve(base, requestPath);
+  const relative = path.relative(base, resolved);
+  if (relative === '' || relative.startsWith('..') || path.isAbsolute(relative)) {
+    return null;
+  }
+  return resolved;
+}
+
+/** True when a contained path sits under one of the servable asset trees. */
+function isServable(resolvedPath) {
+  const [top] = path.relative(PROJECT_ROOT, resolvedPath).split(/[\\/]/);
+  return SERVABLE_ROOTS.includes(top.toLowerCase());
+}
+
 // File content cache (5000 files, 1024MB max)
 const fileCache = new LRUCache(
   parseInt(process.env.CACHE_MAX_FILES) || 5000,
@@ -203,10 +238,11 @@ const Client = {
 
     // Normalize paths
     let grfFilePath = filePath.replace(/\//g, '\\');
-    let localPath = path.join(__dirname, '..', '..', filePath);
 
-    // Check local file system first
-    if (fs.existsSync(localPath)) {
+    // Check local file system first. The path comes straight from the client, so it
+    // is only read when it stays inside the project and lands in an asset tree.
+    const localPath = resolveContained(PROJECT_ROOT, filePath);
+    if (localPath && isServable(localPath) && fs.existsSync(localPath)) {
       try {
         const content = fs.readFileSync(localPath);
         fileCache.set(cacheKey, content);
@@ -219,8 +255,9 @@ const Client = {
     // Check DATA_OVERRIDE_PATH (external data dir with loose files not in GRF)
     if (process.env.DATA_OVERRIDE_PATH) {
       const relativePath = filePath.replace(/^data[\/\\]/, '');
-      const overridePath = path.resolve(__dirname, '..', '..', process.env.DATA_OVERRIDE_PATH, relativePath);
-      if (fs.existsSync(overridePath)) {
+      const overrideBase = path.resolve(PROJECT_ROOT, process.env.DATA_OVERRIDE_PATH);
+      const overridePath = resolveContained(overrideBase, relativePath);
+      if (overridePath && fs.existsSync(overridePath)) {
         try {
           const content = fs.readFileSync(overridePath);
           fileCache.set(cacheKey, content);

--- a/src/controllers/clientController.js
+++ b/src/controllers/clientController.js
@@ -440,19 +440,35 @@ const Client = {
     return Array.from(allFiles);
   },
 
-  search(regex) {
+  /**
+   * Search the file index with a client-supplied regex.
+   *
+   * The pattern is attacker-controlled and the index holds millions of entries, so
+   * the scan is bounded by a wall-clock budget and a result cap. This limits how
+   * many regex evaluations a hostile pattern gets; it does not make an individual
+   * evaluation cheap, which is why routes/index.js also caps the pattern length.
+   */
+  search(regex, { limit = 10000, timeBudgetMs = 2000 } = {}) {
     if (!configs.CLIENT_ENABLESEARCH) {
       logger.warn('Search feature is disabled');
       return [];
     }
 
     const matchingFiles = new Set();
+    const deadline = Date.now() + timeBudgetMs;
 
     // Use index for faster search
     if (indexBuilt) {
+      let scanned = 0;
       for (const [, entry] of fileIndex) {
+        // Date.now() per entry would dominate the loop; sample it instead.
+        if ((++scanned & 0x3ff) === 0 && Date.now() > deadline) {
+          logger.warn(`Search aborted after ${scanned} entries: time budget exceeded`);
+          break;
+        }
         if (regex.test(entry.originalPath)) {
           matchingFiles.add(entry.originalPath);
+          if (matchingFiles.size >= limit) break;
         }
       }
       return Array.from(matchingFiles);

--- a/src/middlewares/rawImportMiddleware.js
+++ b/src/middlewares/rawImportMiddleware.js
@@ -25,6 +25,16 @@ const IMPORT_ALIASES = {
   'jquery':  '/src/Vendors/jquery-1.9.1.js',
   'bson':    '/node_modules/bson/lib/bson.mjs',
   'lodash':  '/node_modules/lodash-es/lodash.default.js',
+  // Subpath export "./wasm" of granny-ro-js, used by src/Loaders/GR2Loader.js and
+  // the GR2 renderers. The browser cannot read package.json "exports", so the
+  // subpath is spelled out here.
+  'granny-ro-js/wasm': '/node_modules/granny-ro-js/dist/granny-ro.wasm.esm.js',
+  //
+  // NOT mappable: 'rijndael-js', imported by src/Utils/Rijndael.js. That package
+  // ships CommonJS only (main: index.js, no "module"/"exports", no type: module),
+  // so no static path makes it loadable as an ES module -- serving raw sources
+  // cannot substitute for the CJS-to-ESM conversion a bundler performs. Anything
+  // reaching Utils/Rijndael.js, which means the login flow, still needs a build.
   // Directory aliases (Vite resolve.alias)
   'App/':         '/src/App/',
   'Audio/':       '/src/Audio/',
@@ -114,8 +124,21 @@ function createRawImportMiddleware(rootDir) {
       const filePath = path.join(rootDir, req.path);
       const resolved = path.resolve(filePath);
 
-      // Security: prevent path traversal
-      if (!resolved.startsWith(path.resolve(rootDir))) {
+      // Security: prevent path traversal.
+      //
+      // The boundary separator matters. A bare startsWith(rootDir) also accepts
+      // any sibling whose name merely begins with it -- with rootDir pointing at
+      // roBrowserLegacy, "/../roBrowserLegacy-RemoteClient-JS/.env" passed, and
+      // the ?raw handler would have returned this server's own secrets wrapped in
+      // "export default".
+      const root = path.resolve(rootDir);
+      if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+        return res.status(403).send('Forbidden');
+      }
+
+      // ?raw turns any file into a JS module, so dot-entries (.env, .git/) must
+      // not be reachable through it.
+      if (req.path.split('/').some((segment) => segment.startsWith('.') && segment.length > 1)) {
         return res.status(403).send('Forbidden');
       }
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -44,6 +44,23 @@ function setCacheHeaders(res, filePath, content, cachedETag) {
   return null;
 }
 
+// Longest accepted /search pattern. The client sends RegExp.source, which is short
+// in practice; the cap keeps a hostile pattern from being arbitrarily complex.
+const MAX_FILTER_LENGTH = 256;
+
+// Ceiling on the raw bytes one /batch response may assemble in memory. Bodies are
+// base64-encoded on top of this, so the socket sees roughly 4/3 of it.
+const MAX_BATCH_BYTES = 32 * 1024 * 1024;
+
+/**
+ * Wrap an async handler so a rejected promise reaches Express instead of
+ * surfacing as an unhandled rejection. Express 4 does not await handlers, so
+ * without this an async throw crashes the process.
+ */
+function asyncRoute(handler) {
+  return (req, res, next) => Promise.resolve(handler(req, res, next)).catch(next);
+}
+
 // Check if client has valid cached version
 function checkConditionalRequest(req, etag) {
   const ifNoneMatch = req.headers['if-none-match'];
@@ -60,46 +77,70 @@ function checkConditionalRequest(req, etag) {
 
 router.post('/search', (req, res) => {
   const filter = req.body.filter;
-  if (!configs.CLIENT_ENABLESEARCH || !filter) {
+  if (!configs.CLIENT_ENABLESEARCH || typeof filter !== 'string' || filter.length === 0) {
     return res.status(400).send('Search feature is disabled or invalid filter');
   }
 
-  const regex = new RegExp(filter, 'i');
+  if (filter.length > MAX_FILTER_LENGTH) {
+    return res.status(400).send(`Filter too long (max ${MAX_FILTER_LENGTH} characters)`);
+  }
+
+  let regex;
+  try {
+    regex = new RegExp(filter, 'i');
+  } catch (e) {
+    return res.status(400).send('Invalid regular expression');
+  }
+
   const files = Client.search(regex);
   res.send(files.join('\n'));
 });
 
 // Batch file endpoint - fetch multiple files in a single request
-router.post('/batch', async (req, res) => {
+router.post('/batch', asyncRoute(async (req, res) => {
   const { files } = req.body;
   if (!Array.isArray(files) || files.length === 0 || files.length > 50) {
     return res.status(400).json({ error: 'Invalid files array (1-50 files)' });
   }
 
   const results = {};
+  let totalBytes = 0;
+  let truncated = false;
+
   await Promise.all(files.map(async (filePath) => {
+    if (typeof filePath !== 'string') return;
     try {
       const content = await Client.getFile(filePath);
-      if (content) {
-        results[filePath] = content.toString('base64');
+      if (!content) return;
+
+      // 50 files carry no size limit of their own; without this a caller can ask
+      // for the largest assets in the archive and pin them all in memory at once.
+      if (totalBytes + content.length > MAX_BATCH_BYTES) {
+        truncated = true;
+        return;
       }
+      totalBytes += content.length;
+      results[filePath] = content.toString('base64');
     } catch (e) {
       // Skip files that fail
     }
   }));
 
+  if (truncated) {
+    res.set('X-Batch-Truncated', '1');
+  }
   res.json(results);
-});
+}));
 
 // List files endpoint
-router.get('/list-files', async (req, res) => {
+router.get('/list-files', asyncRoute(async (req, res) => {
   const files = Client.listFiles();
   res.set('Cache-Control', 'public, max-age=300'); // Cache for 5 minutes
   res.json(files);
-});
+}));
 
 // Wildcard route for file serving
-router.get('/*', async (req, res) => {
+router.get('/*', asyncRoute(async (req, res) => {
   const filePath = req.params[0];
 
   // Serve index.html for root
@@ -148,6 +189,6 @@ router.get('/*', async (req, res) => {
   }
 
   res.send(fileContent);
-});
+}));
 
 module.exports = router;

--- a/src/validators/startupValidator.js
+++ b/src/validators/startupValidator.js
@@ -242,12 +242,26 @@ class StartupValidator {
       return { ok: false, reason: `Invalid signature: "${signature}"` };
     }
 
-    const tableOffset = header.readUInt32LE(30) >>> 0;
     const seed = header.readUInt32LE(34) >>> 0;
     const nFiles = header.readUInt32LE(38) >>> 0;
     const version = header.readUInt32LE(42) >>> 0;
 
-    const fileCount = Math.max(nFiles - seed - 7, 0);
+    // 0x200 and 0x300 lay out these fields differently. Mirrors the reference
+    // implementation in roBrowserLegacy, src/Loaders/GameFile.js.
+    //
+    // 0x300 stores the table offset as a 64-bit value spanning bytes 30..37 -- so
+    // what is the "seed" field in 0x200 is the high half of that offset here --
+    // and its file count is literal. 0x200 stores a 32-bit offset and encodes the
+    // count as nFiles - seed - 7.
+    let tableOffset;
+    let fileCount;
+    if (version === 0x300) {
+      tableOffset = Number(header.readBigUInt64LE(30));
+      fileCount = nFiles;
+    } else {
+      tableOffset = header.readUInt32LE(30) >>> 0;
+      fileCount = Math.max(nFiles - seed - 7, 0);
+    }
 
     return {
       ok: true,
@@ -404,7 +418,10 @@ class StartupValidator {
     const scanLimit =
       scanLimitEnv && /^\d+$/.test(scanLimitEnv) ? parseInt(scanLimitEnv, 10) : 0; // 0 = full
 
-    const fileTablePos = headerInfo.tableOffset + 46; // correct per spec
+    // 0x300 carries an extra unknown Int32 between the header and the file table
+    // (see roBrowserLegacy, src/Loaders/GameFile.js).
+    const fileTablePos =
+      headerInfo.tableOffset + 46 + (headerInfo.version === 0x300 ? 4 : 0);
     const table = this._inflateFileTable(fd, fileTablePos);
     if (!table.ok) {
       return {


### PR DESCRIPTION
## Why

The project could not be installed by anyone. Two independent blockers, both hit on a clean clone before a single line of server code runs. While fixing them I ran a full validation of the codebase, which surfaced four more issues serious enough to ship here: arbitrary file read, two denial-of-service paths, and a GRF format the validator rejects despite advertising support for it.

## The two install blockers

**1. A dependency pointing at a local disk path.** `package.json` declared `"@chicowall/robrowser-esrgan": "file:../../robrowser-esrgan"`, which resolves to a directory that exists on no machine — not even mine; the real one sits elsewhere. Being a hard `dependency`, it failed `npm install` for everyone, including users who never enable ESRGAN.

The plugin is published at [github.com/FranciscoWallison/robrowser-esrgan](https://github.com/FranciscoWallison/robrowser-esrgan) (public) but not on npm, so the dependency now points there and moved to `optionalDependencies`, since upscaling is opt-in behind `ESRGAN_ENABLED`.

**2. `prepare` is an npm lifecycle hook.** `"prepare": "node prepare.js"` ran automatically on every `npm install`. On a fresh clone the script validates Ragnarok client files that have not been copied in yet — `resources/` ships empty and is gitignored — so it exited non-zero and took the install down with it:

```
✗ config: DATA.INI not found: .../resources/DATA.INI
npm error code 1
npm error command failed
npm error command node prepare.js
```

The script was never meant to run automatically; its own header documents it as a manual command. Renamed to `setup` / `setup:quick`, with both READMEs updated. `prepare.js` keeps its filename and its non-zero exit, which is useful signal now that it is only invoked deliberately.

## Security

**Arbitrary file read, and the repository root as document root.** `Client.getFile()` built its path with `path.join(__dirname, '..', '..', filePath)` and read it with no normalisation and no containment check. `filePath` arrives straight from the network through `POST /batch` and the `GET /*` wildcard, and `__dirname/../..` is the repository root. Anything there was downloadable with no `../` needed. Verified against the pre-fix code:

```
GET /.env.testonly  -> 23 bytes
GET /.git/config    -> 445 bytes
GET /package.json   -> 1081 bytes
GET /index.js       -> 11325 bytes
```

A real deployment has a real `.env` there, holding `WS_ALLOWED_TARGETS` and `DATA_OVERRIDE_PATH`, and a `.git/` from which the entire history can be reconstructed. Leaked bodies were also written into the LRU cache, so one `/batch` call poisoned what the wildcard route served afterwards.

Reads are now contained, and the project root stops being a document root — only the Ragnarok asset trees (`data`, `BGM`, `System`, `AI`) are reachable. `DATA_OVERRIDE_PATH` is contained the same way; previously an absolute `filePath` reset its base entirely.

**`?raw` escaped into sibling directories.** The raw-import middleware checked containment with `resolved.startsWith(path.resolve(rootDir))`, no separator boundary. With `rootDir` at `.../roBrowserLegacy`, the sibling is `.../roBrowserLegacy-RemoteClient-JS` — this server's own checkout. Confirmed pre-fix: `/../roBrowserLegacy-RemoteClient-JS/.env` cleared the guard and reached `fs.readFile`, and `?raw` would have returned it wrapped in `export default`.

**Dotfiles over `express.static`.** The static mount served the roBrowserLegacy checkout root with dotfiles allowed, exposing that repository's `.git/` and `.env`. Now `dotfiles: 'deny'`.

## Denial of service

**ReDoS on `/search`.** A caller-supplied pattern was compiled with `new RegExp(filter, 'i')` and run over an index of millions of filenames, with no cap on the pattern, the scan or the runtime; an invalid pattern additionally threw and answered 500. Input is now validated (400 on a pattern that does not compile, capped at 256 characters) and the scan is bounded by a wall-clock budget and a result cap.

This limits how many evaluations a hostile pattern gets. It does not make one evaluation cheap — filenames are short, so the residual is small, but it is a mitigation rather than a cure. A pattern-complexity analyser or a worker with a hard timeout would close it properly.

**Unbounded `/batch`.** Fifty paths, each read fully into memory and base64-encoded on top, with no size ceiling anywhere — enough to exhaust the heap. Capped at 32 MB of raw bytes, with `X-Batch-Truncated` marking a clipped response.

**Async handlers crashing the process.** `/batch`, `/list-files` and `GET /*` were async. Express 4 does not await handlers, so a rejected promise became an unhandled rejection and took the process down instead of producing a 500. All three now route through an `asyncRoute()` wrapper.

## Correctness

**GRF 0x300 was rejected as incompatible.** The validator read every header field with the 0x200 layout. 0x300 stores the table offset as a 64-bit value spanning bytes 30..37 — so what 0x200 calls the seed is that offset's high half — its file count is literal rather than `nFiles - seed - 7`, and an unknown Int32 sits between header and table. roBrowserLegacy's own loader documents all three (`src/Loaders/GameFile.js`).

A good 0x300 archive therefore failed with "Failed to read/parse compacted file table", and since startup validation is fatal, the server refused to boot — while the same validator advertises 0x300 as supported in its error text. Verified with synthetic headers:

| case | before | after |
| --- | --- | --- |
| 0x200 | 1000 / 88 (unchanged) | 1000 / 88 |
| 0x300 | 2000 / 93 — file count wrong | 2000 / 100 |
| 0x300, >4 GB offset | 705032704 — offset truncated | 5000000000 |

**`granny-ro-js/wasm` was unresolvable.** `IMPORT_ALIASES` covered `bson` and `lodash` but not the other bare specifiers the sources use, so the module graph died under `ENABLE_STATIC_SERVE`. Added, spelling out the `dist/granny-ro.wasm.esm.js` subpath that `package.json` `exports` declares, since a browser cannot read that field.

## Known gaps, not fixed here

- **`rijndael-js` still cannot load from raw sources.** `src/Utils/Rijndael.js` imports it, and the package ships CommonJS only — no `module`, no `exports`, no `type: module`. No static path makes it importable in a browser; serving raw sources cannot replace the CJS-to-ESM conversion a bundler performs. The login flow that reaches it still needs a build. Documented in place rather than papered over.
- **The `+4` table-position offset for 0x300** is mirrored from the reference loader and is not covered by the header-level checks; no 0x300 archive was available to validate the full parse end to end.
- **No automated tests and no lint in `package.json`.** Verification for this PR was manual, with throwaway harnesses. For a server that resolves client-supplied paths, a regression suite around `getFile()` containment is the single highest-value thing to add next.

## How to verify

```bash
rm -rf node_modules package-lock.json && npm install   # exit 0; previously failed
npm install --omit=optional                            # exit 0 with the plugin absent
```

Both pass. Every `.js`/`.mjs` file in the repo passes `node --check`. The containment, `?raw` and GRF-header behaviours were each checked against the pre-fix code to confirm the old behaviour was genuinely broken and the new one is not.

Full boot could not be exercised here: startup validation is fatal and this machine has no Ragnarok client files, so `npm start` exits before reaching the server. Worth a run against a real client before merging.
