### PR TITLE
fix: gate all three diagnostic endpoints in production (supersedes #17)

### DIFF
--- a/README-pt-br.md
+++ b/README-pt-br.md
@@ -368,9 +368,9 @@ Quando `CLIENT_AUTOEXTRACT=true` (padrao em `src/config/configs.js`), arquivos e
 | Metodo | Rota | Descricao |
 |--------|------|-----------|
 | GET | `/` | Retorna `index.html` |
-| GET | `/api/health` | Status completo do sistema (validacao, cache, indice, arquivos ausentes) |
-| GET | `/api/cache-stats` | Estatisticas de cache e indice |
-| GET | `/api/missing-files` | Lista de arquivos nao encontrados |
+| GET | `/api/health` | Liveness. Detalhe completo (validacao, cache, indice, arquivos ausentes) em desenvolvimento; so status e contagens em producao |
+| GET | `/api/cache-stats` | Estatisticas de cache e indice. Apenas em desenvolvimento — 404 em producao |
+| GET | `/api/missing-files` | Lista de arquivos nao encontrados. Apenas em desenvolvimento — 404 em producao |
 | GET | `/*` | Serve qualquer arquivo do client (do disco, cache ou GRF) |
 | POST | `/search` | Busca arquivos por filtro regex |
 | GET | `/list-files` | Lista todos os arquivos disponiveis |

--- a/README.md
+++ b/README.md
@@ -483,9 +483,9 @@ When `CLIENT_AUTOEXTRACT=true` (default in `src/config/configs.js`), files extra
 | Method | Route | Description |
 |--------|-------|-------------|
 | GET | `/` | Returns `index.html` |
-| GET | `/api/health` | Full system status (validation, cache, index, missing files) |
-| GET | `/api/cache-stats` | Cache and index statistics |
-| GET | `/api/missing-files` | List of files not found |
+| GET | `/api/health` | Liveness. Full detail (validation, cache, index, missing files) in development; status and counts only in production |
+| GET | `/api/cache-stats` | Cache and index statistics. Development only — 404 in production |
+| GET | `/api/missing-files` | List of files not found. Development only — 404 in production |
 | GET | `/*` | Serves any client file (from disk, cache, or GRF) |
 | POST | `/search` | Search files by regex filter |
 | GET | `/list-files` | List all available files |

--- a/index.js
+++ b/index.js
@@ -136,15 +136,18 @@ async function startServer() {
     });
   });
 
-  // Missing files endpoint
+  // Missing files endpoint (diagnostics: dev-only, hidden in production to avoid
+  // leaking file structure/index internals to unauthenticated callers)
   app.get('/api/missing-files', (req, res) => {
+    if (IS_PROD) return res.status(404).end();
     const Client = require('./src/controllers/clientController');
     const summary = Client.getMissingFilesSummary ? Client.getMissingFilesSummary() : { total: 0, files: [] };
     res.json(summary);
   });
 
-  // Cache stats endpoint
+  // Cache stats endpoint (diagnostics: dev-only, same rationale as above)
   app.get('/api/cache-stats', (req, res) => {
+    if (IS_PROD) return res.status(404).end();
     const Client = require('./src/controllers/clientController');
     res.json({
       cache: Client.getCacheStats ? Client.getCacheStats() : null,

--- a/index.js
+++ b/index.js
@@ -120,15 +120,32 @@ async function startServer() {
     }
   }
 
-  // Validation status endpoint (JSON for frontend)
+  // Validation status endpoint (JSON for frontend).
+  //
+  // Unlike the two diagnostic endpoints below this one cannot 404 in production:
+  // load balancers and container health checks call it. So it stays reachable but
+  // answers with liveness only, withholding the reconnaissance detail -- absolute
+  // paths, GRF names, Node/npm versions, cache and index internals -- that the
+  // full payload carries.
   app.get('/api/health', (req, res) => {
+    const status = validationStatus || {};
+
+    if (IS_PROD) {
+      return res.json({
+        timestamp: status.timestamp,
+        status: status.status,
+        hasWarnings: status.hasWarnings,
+        summary: status.summary,
+      });
+    }
+
     const Client = require('./src/controllers/clientController');
     const missingInfo = Client.getMissingFilesSummary ? Client.getMissingFilesSummary() : null;
     const cacheStats = Client.getCacheStats ? Client.getCacheStats() : null;
     const indexStats = Client.getIndexStats ? Client.getIndexStats() : null;
 
     res.json({
-      ...validationStatus,
+      ...status,
       missingFiles: missingInfo,
       cache: cacheStats,
       index: indexStats,


### PR DESCRIPTION
Supersedes #17, keeping its commit and its author.

## Why not merge #17 directly

The change in #17 is sound — I reviewed the diff byte for byte: 1007 bytes, pure printable ASCII, no homoglyphs or invisible characters, and it touches nothing outside `index.js` (no workflows, no `package.json`, no shell scripts).

Its branch, however, was cut from a commit that predates a history cleanup on `main`. Merging it would have fast-forwarded 44 commits back in, taking `main` from 84 to roughly 129 commits and restoring duplicated history. GitHub reports the PR as mergeable and clean, which hides that. So the commit is cherry-picked here instead, unchanged and still authored by @anupamme.

## Why the original fix was not enough

#17 gates `/api/missing-files` and `/api/cache-stats` behind `IS_PROD`, and leaves `/api/health` untouched. But `/api/health` returns a superset of both:

```js
res.json({
  ...validationStatus,        // absolute paths, GRF names, Node/npm versions,
                              // every startup error and warning
  missingFiles: missingInfo,  // same as /api/missing-files
  cache: cacheStats,          // same as /api/cache-stats
  index: indexStats,          //  "
  esrgan: ...,
});
```

Closing the two narrower endpoints while the widest one stayed unauthenticated closed nothing. An attacker doing reconnaissance would simply read `/api/health`.

## What the second commit does

`/api/health` cannot 404 the way the other two can — load balancers and container health checks call it, and `index.html` renders it. So it stays reachable in production and answers with liveness only:

| | development | production |
| --- | --- | --- |
| `timestamp`, `status`, `hasWarnings`, `summary` | yes | yes |
| `details`, `messages` | yes | **withheld** |
| `missingFiles`, `cache`, `index`, `esrgan` | yes | **withheld** |

The diagnostic page keeps the full payload it is built around whenever `NODE_ENV` is not `production`.

Both READMEs are updated: their API tables described `/api/health` as "full system status" unconditionally, and did not mention that the other two endpoints now 404 outside development.

## Verification

- The production branch of `/api/health` exposes exactly `timestamp`, `status`, `hasWarnings`, `summary` — and none of `details`, `messages`, `missingFiles`, `cache`, `index`, `esrgan`. Asserted programmatically against the source, not by eye.
- All three endpoints confirmed gated: two answering 404, one answering a reduced payload.
- Every `.js`/`.mjs` file in the repo passes `node --check`.
- The existing regression checks still pass: 0 path-containment leaks with the happy path intact, 0 `?raw` escapes, and 3/3 GRF header cases.

Not covered: no live boot. Startup validation is fatal and this machine has no Ragnarok client files, so `npm start` exits before the server comes up. The endpoint behaviour was verified against the source rather than over HTTP; worth one `curl` against a real deployment with `NODE_ENV=production` before relying on it.
