### PR TITLE
fix: bound the search ReDoS in a worker, repair the encoding tools, document remoteClient

### DIFF
--- a/README-pt-br.md
+++ b/README-pt-br.md
@@ -242,9 +242,18 @@ Quando nao definido, usa os destinos localhost padrao (`127.0.0.1:6900/6121/5121
 
 **Configuracao do roBrowserLegacy** (`Config.local.js`):
 ```js
+remoteClient: 'http://127.0.0.1:3338/',  // OBRIGATORIO - veja abaixo
 socketProxy: 'ws://127.0.0.1:3338/ws/'  // modo unificado
 // socketProxy: 'ws://127.0.0.1:5999/'  // modo separado (legado)
 ```
+
+**O `remoteClient` nao e opcional.** O roBrowserLegacy vem com
+`remoteClient: 'https://grf.robrowser.com/'` como padrao
+(`applications/pwa/Config.js`), e esse unico valor decide de onde vem cada
+asset. Sem defini-lo, o cliente carrega tudo do CDN publico em silencio — o jogo
+roda, nada parece quebrado, e este servidor nunca e usado. A barra final e
+obrigatoria: o cliente concatena direto (`remoteClient + url` e
+`remoteClient + 'batch'`).
 
 ### Servidor de Arquivos Estaticos Embutido
 
@@ -569,9 +578,10 @@ O servidor registra arquivos ausentes em `logs/missing-files.log`. Verifique:
 
 1. Verifique `ENABLE_WSPROXY=true` no `.env`
 2. Confira se `Config.local.js` tem `socketProxy: 'ws://127.0.0.1:3338/ws/'`
-3. Garanta que o rAthena esta rodando (login:6900, char:6121, map:5121)
-4. Verifique os logs do servidor por mensagens `WS proxy blocked connection`
-5. Para Docker/rAthena remoto: defina `WS_ALLOWED_TARGETS` no `.env` (veja [Variaveis de Ambiente](#variaveis-de-ambiente))
+3. Assets vindo de `grf.robrowser.com` em vez deste servidor: falta `remoteClient` no `Config.local.js`
+4. Garanta que o rAthena esta rodando (login:6900, char:6121, map:5121)
+5. Verifique os logs do servidor por mensagens `WS proxy blocked connection`
+6. Para Docker/rAthena remoto: defina `WS_ALLOWED_TARGETS` no `.env` (veja [Variaveis de Ambiente](#variaveis-de-ambiente))
 
 ### Problemas Comuns
 

--- a/README.md
+++ b/README.md
@@ -245,9 +245,18 @@ When not set, defaults to localhost targets (`127.0.0.1:6900/6121/5121`).
 
 **roBrowserLegacy configuration** (`Config.local.js`):
 ```js
+remoteClient: 'http://127.0.0.1:3338/',  // REQUIRED - see below
 socketProxy: 'ws://127.0.0.1:3338/ws/'  // unified mode
 // socketProxy: 'ws://127.0.0.1:5999/'  // separate mode (legacy)
 ```
+
+**`remoteClient` is not optional.** roBrowserLegacy ships with
+`remoteClient: 'https://grf.robrowser.com/'` as its default
+(`applications/pwa/Config.js`), and that single value decides where every asset
+comes from. Leave it unset and the client quietly loads everything from the
+public CDN — the game runs, nothing looks broken, and this server is never used.
+The trailing slash is required: the client concatenates directly
+(`remoteClient + url`, and `remoteClient + 'batch'`).
 
 ### Embedded Static File Server
 
@@ -684,9 +693,10 @@ The server logs missing files to `logs/missing-files.log`. Check:
 
 1. Verify `ENABLE_WSPROXY=true` in `.env`
 2. Check `Config.local.js` has `socketProxy: 'ws://127.0.0.1:3338/ws/'`
-3. Ensure rAthena is running (login:6900, char:6121, map:5121)
-4. Check server logs for `WS proxy blocked connection` messages
-5. For Docker/remote rAthena: set `WS_ALLOWED_TARGETS` in `.env` (see [Environment Variables](#environment-variables))
+3. Assets loading from `grf.robrowser.com` instead of this server: `remoteClient` is missing from `Config.local.js`
+4. Ensure rAthena is running (login:6900, char:6121, map:5121)
+5. Check server logs for `WS proxy blocked connection` messages
+6. For Docker/remote rAthena: set `WS_ALLOWED_TARGETS` in `.env` (see [Environment Variables](#environment-variables))
 
 ### Common Issues
 

--- a/src/controllers/clientController.js
+++ b/src/controllers/clientController.js
@@ -4,6 +4,7 @@ const Grf = require('./grfController');
 const configs = require('../config/configs');
 const LRUCache = require('../utils/LRUCache');
 const logger = require('../utils/logger');
+const searchPool = require('../utils/searchPool');
 const iconv = require('iconv-lite');
 
 /**
@@ -64,6 +65,14 @@ const fileCache = new LRUCache(
 // GRF file index for O(1) lookups: filename → { grfIndex, originalPath }
 let fileIndex = new Map();
 let indexBuilt = false;
+
+/**
+ * Memoized result of listFiles(). Rebuilding it walks every index entry into a Set -- 67 ms for a
+ * full data.grf -- and both /list-files and every search need it. Identity matters too: the search
+ * worker keeps its copy keyed on this array, and a fresh array each call would re-send 9 MB per
+ * query. Cleared whenever the index is rebuilt.
+ */
+let cachedFileList = null;
 
 // Path mapping for encoding conversion (loaded from path-mapping.json if exists)
 let pathMapping = null;
@@ -197,6 +206,10 @@ const Client = {
     if (mojibakeCount > 0) {
       logger.debug(`Added ${mojibakeCount} mojibake path mappings for roBrowser compatibility`);
     }
+
+    // The file list and the search worker both cache what the index holds.
+    cachedFileList = null;
+    searchPool.invalidate();
 
     // Add path mapping entries to index
     if (pathMapping && pathMapping.paths) {
@@ -422,11 +435,14 @@ const Client = {
   listFiles() {
     // Use index if available for faster response
     if (indexBuilt) {
+      if (cachedFileList) return cachedFileList;
+
       const uniqueFiles = new Set();
       for (const [, entry] of fileIndex) {
         uniqueFiles.add(entry.originalPath);
       }
-      return Array.from(uniqueFiles);
+      cachedFileList = Array.from(uniqueFiles);
+      return cachedFileList;
     }
 
     // Fallback to GRF iteration
@@ -443,50 +459,29 @@ const Client = {
   /**
    * Search the file index with a client-supplied regex.
    *
-   * The pattern is attacker-controlled and the index holds millions of entries, so
-   * the scan is bounded by a wall-clock budget and a result cap. This limits how
-   * many regex evaluations a hostile pattern gets; it does not make an individual
-   * evaluation cheap, which is why routes/index.js also caps the pattern length.
+   * The pattern is attacker-controlled, and a catastrophic one cannot be interrupted mid-evaluation:
+   * `^(.+)+#$` against a 30-character path takes seconds and doubles with each extra character,
+   * while GRF paths run 40-60. Checking a time budget between candidates does not help, because the
+   * cost is inside a single RegExp.test() call.
+   *
+   * So the matching runs in a worker thread that the caller can terminate on overrun. This keeps the
+   * event loop free: the process stays responsive while a hostile pattern burns, and the worker is
+   * replaced for the next query.
+   *
+   * @returns {Promise<string[]>}
+   * @throws if the query exceeds its deadline -- the caller should answer 503.
    */
-  search(regex, { limit = 10000, timeBudgetMs = 2000 } = {}) {
+  async search(regex, { limit = 10000, timeBudgetMs = 2000 } = {}) {
     if (!configs.CLIENT_ENABLESEARCH) {
       logger.warn('Search feature is disabled');
       return [];
     }
 
-    const matchingFiles = new Set();
-    const deadline = Date.now() + timeBudgetMs;
-
-    // Use index for faster search
-    if (indexBuilt) {
-      let scanned = 0;
-      for (const [, entry] of fileIndex) {
-        // Date.now() per entry would dominate the loop; sample it instead.
-        if ((++scanned & 0x3ff) === 0 && Date.now() > deadline) {
-          logger.warn(`Search aborted after ${scanned} entries: time budget exceeded`);
-          break;
-        }
-        if (regex.test(entry.originalPath)) {
-          matchingFiles.add(entry.originalPath);
-          if (matchingFiles.size >= limit) break;
-        }
-      }
-      return Array.from(matchingFiles);
-    }
-
-    // Fallback
-    for (const grf of this.grfs) {
-      if (grf && grf.listFiles) {
-        const files = grf.listFiles();
-        files.forEach(file => {
-          if (regex.test(file)) {
-            matchingFiles.add(file);
-          }
-        });
-      }
-    }
-
-    return Array.from(matchingFiles);
+    const candidates = this.listFiles();
+    return searchPool.search(regex.source, regex.flags, candidates, {
+      limit,
+      timeoutMs: timeBudgetMs,
+    });
   },
 
   /**

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -75,7 +75,7 @@ function checkConditionalRequest(req, etag) {
   await Client.init();
 })();
 
-router.post('/search', (req, res) => {
+router.post('/search', asyncRoute(async (req, res) => {
   const filter = req.body.filter;
   if (!configs.CLIENT_ENABLESEARCH || typeof filter !== 'string' || filter.length === 0) {
     return res.status(400).send('Search feature is disabled or invalid filter');
@@ -92,9 +92,15 @@ router.post('/search', (req, res) => {
     return res.status(400).send('Invalid regular expression');
   }
 
-  const files = Client.search(regex);
-  res.send(files.join('\n'));
-});
+  try {
+    const files = await Client.search(regex);
+    res.send(files.join('\n'));
+  } catch (err) {
+    // The pattern overran its deadline and the worker was terminated. This is the expected
+    // outcome for a catastrophic pattern, not a server fault worth a 500.
+    res.status(503).send('Search timed out: pattern too expensive');
+  }
+}));
 
 // Batch file endpoint - fetch multiple files in a single request
 router.post('/batch', asyncRoute(async (req, res) => {

--- a/src/utils/searchPool.js
+++ b/src/utils/searchPool.js
@@ -1,0 +1,109 @@
+/**
+ * Owns the single worker thread that runs client-supplied regex searches.
+ *
+ * The worker holds its own copy of the path list (~9 MB for a full data.grf) so a query costs one
+ * small message rather than re-sending 170k strings. Every query races a deadline; on overrun the
+ * worker is terminated -- which is the whole point, since a catastrophic backtrack cannot be
+ * interrupted any other way -- and a fresh one is seeded on the next call.
+ */
+const path = require('node:path');
+const { Worker } = require('node:worker_threads');
+const logger = require('./logger');
+
+const WORKER_PATH = path.join(__dirname, 'searchWorker.js');
+
+let worker = null;
+let seededWith = null;
+let nextQueryId = 1;
+const pending = new Map();
+
+/** Reject everything in flight and drop the worker. Used on timeout and on worker death. */
+function discardWorker(reason) {
+  const dying = worker;
+  worker = null;
+  seededWith = null;
+
+  for (const [, entry] of pending) {
+    clearTimeout(entry.timer);
+    entry.reject(new Error(reason));
+  }
+  pending.clear();
+
+  if (dying) dying.terminate().catch(() => {});
+}
+
+function ensureWorker() {
+  if (worker) return worker;
+
+  const created = new Worker(WORKER_PATH);
+  worker = created;
+  created.unref(); // must not keep the process alive on shutdown
+
+  created.on('message', (msg) => {
+    if (msg.type !== 'result') return;
+    const entry = pending.get(msg.id);
+    if (!entry) return; // already timed out
+    clearTimeout(entry.timer);
+    pending.delete(msg.id);
+    entry.resolve(msg.matches);
+  });
+
+  // Both handlers check `created === worker` first. A terminated worker still emits 'exit'
+  // (with a non-zero code), and by then `worker` may already point at its replacement --
+  // acting on that event unconditionally would kill the fresh worker and fail the next query.
+  created.on('error', (err) => {
+    if (created !== worker) return;
+    logger.error('Search worker error:', err.message);
+    discardWorker(`search worker failed: ${err.message}`);
+  });
+
+  created.on('exit', (code) => {
+    if (created !== worker || code === 0) return;
+    discardWorker(`search worker exited with code ${code}`);
+  });
+
+  return created;
+}
+
+/** Send the path list to the worker, once per worker instance. */
+function seed(paths) {
+  const active = ensureWorker();
+  if (seededWith === paths) return;
+  active.postMessage({ type: 'seed', paths });
+  seededWith = paths;
+}
+
+/**
+ * Run `pattern` against `paths` in the worker.
+ *
+ * @returns {Promise<string[]>} the matches, or a rejection if the query overran `timeoutMs`.
+ */
+function search(pattern, flags, paths, { limit = 10000, timeoutMs = 2000 } = {}) {
+  seed(paths);
+
+  const id = nextQueryId++;
+  const active = worker;
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      pending.delete(id);
+      logger.warn(`Search aborted after ${timeoutMs}ms: terminating worker (pattern too costly)`);
+      discardWorker('search timed out');
+      reject(new Error('search timed out'));
+    }, timeoutMs);
+
+    // Do not hold the event loop open purely to wait on a search.
+    if (typeof timer.unref === 'function') timer.unref();
+
+    pending.set(id, { resolve, reject, timer });
+    active.postMessage({ type: 'query', id, pattern, flags, limit });
+  });
+}
+
+/** Drop the cached path list so the next search re-seeds. Call after the index is rebuilt. */
+function invalidate() {
+  seededWith = null;
+  if (worker) discardWorker('index rebuilt');
+}
+
+module.exports = { search, invalidate };

--- a/src/utils/searchWorker.js
+++ b/src/utils/searchWorker.js
@@ -1,0 +1,40 @@
+/**
+ * Regex search, run off the main thread.
+ *
+ * A caller-supplied pattern can backtrack exponentially -- `^(.+)+#$` against a 30-character path
+ * takes seconds, and doubles with every additional character, while GRF paths run 40-60 characters.
+ * No amount of budget-checking between evaluations helps, because the cost is inside one
+ * `RegExp.test()` call that nothing can interrupt.
+ *
+ * Running it in a worker makes it interruptible: the main thread races every query against a
+ * deadline and terminates this thread outright when it overruns. That is the only reliable way to
+ * bound an untrusted regex without a linear-time engine.
+ */
+const { parentPort } = require('node:worker_threads');
+
+/** @type {string[]} The paths to match against, sent once by the main thread. */
+let paths = [];
+
+parentPort.on('message', (msg) => {
+  if (msg.type === 'seed') {
+    paths = msg.paths;
+    parentPort.postMessage({ type: 'seeded', count: paths.length });
+    return;
+  }
+
+  if (msg.type === 'query') {
+    // A pattern that does not compile is rejected by the caller before it gets here; compiling
+    // again in this thread is cheap and keeps the worker self-contained.
+    const regex = new RegExp(msg.pattern, msg.flags);
+    const matches = [];
+
+    for (const candidate of paths) {
+      if (regex.test(candidate)) {
+        matches.push(candidate);
+        if (matches.length >= msg.limit) break;
+      }
+    }
+
+    parentPort.postMessage({ type: 'result', id: msg.id, matches });
+  }
+});

--- a/tests/search-redos.test.js
+++ b/tests/search-redos.test.js
@@ -1,0 +1,71 @@
+/**
+ * Regex search must stay interruptible.
+ *
+ * POST /search compiles a caller-supplied pattern and runs it over every indexed path. A pattern
+ * like `^(.+)+#$` backtracks exponentially: measured in this environment it takes ~93 ms against 24
+ * characters and roughly doubles per character, while GRF paths run 40-60 -- hours of blocked event
+ * loop from one request. And because express.urlencoded is mounted, the form-encoded POST the
+ * roBrowser client uses is a CORS *simple* request: no preflight, so any page the victim visits can
+ * fire it.
+ *
+ * An earlier attempt bounded the scan with a wall-clock budget sampled every 1024 candidates. That
+ * bounds many cheap evaluations, not one expensive one -- the cost is inside a single
+ * RegExp.test() that nothing on that thread can interrupt. Hence the worker, which can be killed.
+ */
+const test = require('node:test');
+const assert = require('node:assert');
+
+const searchPool = require('../src/utils/searchPool');
+
+const PATHS = [
+  'data/sprite/monstro/poring_ataque_frente.spr',
+  'data/texture/basepic/loading01.jpg',
+  'data/texture/basepic/loading00.jpg',
+];
+
+// Classic catastrophic pattern, well inside the 256-character cap the route enforces.
+const EVIL = '^(.+)+#$';
+
+test('an ordinary pattern still returns its matches', async () => {
+  const matches = await searchPool.search('loading', 'i', PATHS, { timeoutMs: 5000 });
+  assert.strictEqual(matches.length, 2);
+  assert.ok(matches.every((m) => m.includes('loading')));
+});
+
+test('the result limit is honoured', async () => {
+  const matches = await searchPool.search('loading', 'i', PATHS, { timeoutMs: 5000, limit: 1 });
+  assert.strictEqual(matches.length, 1);
+});
+
+test('a catastrophic pattern is aborted at the deadline instead of running forever', async () => {
+  const started = Date.now();
+  await assert.rejects(
+    () => searchPool.search(EVIL, 'i', PATHS, { timeoutMs: 1000 }),
+    /timed out/
+  );
+  const elapsed = Date.now() - started;
+  assert.ok(elapsed < 5000, `abort took ${elapsed}ms — the deadline is not being enforced`);
+});
+
+test('the event loop stays responsive while a hostile pattern burns', async () => {
+  let ticks = 0;
+  const ticker = setInterval(() => { ticks++; }, 50);
+
+  await assert.rejects(() => searchPool.search(EVIL, 'i', PATHS, { timeoutMs: 1000 }));
+  clearInterval(ticker);
+
+  // Without the worker this thread would be wedged inside RegExp.test and tick zero times.
+  assert.ok(ticks > 5, `only ${ticks} timer ticks during the attack — the main thread was blocked`);
+});
+
+test('searches keep working after a worker is terminated', async () => {
+  await assert.rejects(() => searchPool.search(EVIL, 'i', PATHS, { timeoutMs: 500 }));
+
+  const matches = await searchPool.search('loading', 'i', PATHS, { timeoutMs: 5000 });
+  assert.strictEqual(matches.length, 2, 'the pool did not recover after terminating the worker');
+});
+
+test.after(() => {
+  // Release the worker so the test runner can exit.
+  searchPool.invalidate();
+});

--- a/tools/convert-encoding.mjs
+++ b/tools/convert-encoding.mjs
@@ -11,12 +11,20 @@
  * Note: This tool does NOT modify GRF files. It creates a lookup table for runtime path resolution.
  */
 
-import * as grfLoader from "@chicowall/grf-loader";
 import { openSync, closeSync, writeFileSync, existsSync, readFileSync } from "fs";
 import path from "path";
 import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
+
+// Load the CommonJS build on purpose.
+//
+// The package's ESM build resolves iconv-lite through a bundler shim that needs a global `require`.
+// Under `node -e` one exists and everything appears to work; inside a real .mjs there is none, the
+// shim throws, iconv-lite is null, and isMojibake/fixMojibake/toMojibake silently become identity
+// functions. That made `npm run convert:encoding` produce an empty mapping while reporting success,
+// and made the validators flag encoding errors in archives the server reads perfectly.
+const grfLoader = require("@chicowall/grf-loader");
 const { GrfNode } = grfLoader;
 
 // These functions may or may not be exported depending on version

--- a/tools/test-mojibake.mjs
+++ b/tools/test-mojibake.mjs
@@ -8,14 +8,15 @@
  *  node tools/test-mojibake.mjs
  */
 
-import {
-  isMojibake,
-  fixMojibake,
-  toMojibake,
-  normalizeFilename,
-  normalizeEncodingPath,
-  hasIconvLite
-} from "@chicowall/grf-loader";
+// Load the CommonJS build on purpose.
+//
+// The package's ESM build resolves iconv-lite through a bundler shim that needs a global `require`.
+// Under `node -e` one exists and everything appears to work; inside a real .mjs there is none, the
+// shim throws, iconv-lite is null, and isMojibake/fixMojibake/toMojibake silently become identity
+// functions. That made `npm run convert:encoding` produce an empty mapping while reporting success,
+// and made the validators flag encoding errors in archives the server reads perfectly.
+import { createRequire } from "module";
+const { isMojibake, fixMojibake, toMojibake, normalizeFilename, normalizeEncodingPath, hasIconvLite } = createRequire(import.meta.url)("@chicowall/grf-loader");
 
 console.log("=".repeat(70));
 console.log("Mojibake Detection & Fixing Test");

--- a/tools/validate-all-grfs.mjs
+++ b/tools/validate-all-grfs.mjs
@@ -16,7 +16,15 @@
  *  node tools/validate-all-grfs.mjs ./resources cp949 --read=300
  */
 
-import { GrfNode } from "@chicowall/grf-loader";
+// Load the CommonJS build on purpose.
+//
+// The package's ESM build resolves iconv-lite through a bundler shim that needs a global `require`.
+// Under `node -e` one exists and everything appears to work; inside a real .mjs there is none, the
+// shim throws, iconv-lite is null, and isMojibake/fixMojibake/toMojibake silently become identity
+// functions. That made `npm run convert:encoding` produce an empty mapping while reporting success,
+// and made the validators flag encoding errors in archives the server reads perfectly.
+import { createRequire } from "module";
+const { GrfNode } = createRequire(import.meta.url)("@chicowall/grf-loader");
 import { openSync, closeSync, writeFileSync, readdirSync, statSync } from "fs";
 import path from "path";
 import iconv from "iconv-lite";

--- a/tools/validate-grf-iconv.mjs
+++ b/tools/validate-grf-iconv.mjs
@@ -14,7 +14,15 @@
  *  node tools/validate-grf-iconv.mjs .\\resources\\data.grf auto
  */
 
-import { GrfNode } from "@chicowall/grf-loader";
+// Load the CommonJS build on purpose.
+//
+// The package's ESM build resolves iconv-lite through a bundler shim that needs a global `require`.
+// Under `node -e` one exists and everything appears to work; inside a real .mjs there is none, the
+// shim throws, iconv-lite is null, and isMojibake/fixMojibake/toMojibake silently become identity
+// functions. That made `npm run convert:encoding` produce an empty mapping while reporting success,
+// and made the validators flag encoding errors in archives the server reads perfectly.
+import { createRequire } from "module";
+const { GrfNode } = createRequire(import.meta.url)("@chicowall/grf-loader");
 import { openSync, closeSync, writeFileSync } from "fs";
 import path from "path";
 import iconv from "iconv-lite";

--- a/tools/validate-grf.mjs
+++ b/tools/validate-grf.mjs
@@ -16,7 +16,15 @@
  *  node tools/validate-grf.mjs .\\resources\\data.grf auto extract-all
  */
 
-import { GrfNode } from "@chicowall/grf-loader";
+// Load the CommonJS build on purpose.
+//
+// The package's ESM build resolves iconv-lite through a bundler shim that needs a global `require`.
+// Under `node -e` one exists and everything appears to work; inside a real .mjs there is none, the
+// shim throws, iconv-lite is null, and isMojibake/fixMojibake/toMojibake silently become identity
+// functions. That made `npm run convert:encoding` produce an empty mapping while reporting success,
+// and made the validators flag encoding errors in archives the server reads perfectly.
+import { createRequire } from "module";
+const { GrfNode } = createRequire(import.meta.url)("@chicowall/grf-loader");
 import { openSync, closeSync, writeFileSync } from "fs";
 import path from "path";
 


### PR DESCRIPTION
Stacked on #20. Three findings from a re-audit of the codebase, in descending order of how badly they bite.

## 1. A single request could wedge the server indefinitely

`POST /search` compiles a caller-supplied pattern and runs it over every indexed path. The previous mitigation bounded the scan with a wall-clock budget sampled every 1024 candidates — which bounds *many cheap* evaluations, not *one expensive* one. The cost lives inside a single `RegExp.test()` that nothing on that thread can interrupt.

`^(.+)+#$` backtracks exponentially: ~93 ms against 24 characters, roughly doubling per character, while GRF paths run 40–60. Replaying the old code path with **two** paths and a 1000 ms budget **did not finish in 120 seconds**.

And it is reachable cross-origin. `express.urlencoded` is mounted (`index.js:77`), so the form-encoded POST the roBrowser client uses is a CORS **simple** request — no preflight — meaning any page a victim visits can fire it. CORS blocks reading the response, not sending it.

Matching now runs in a worker thread the main thread can terminate on overrun. That is the only reliable way to bound an untrusted regex short of a linear-time engine. Measured end to end against a real 3.47 GB archive, 605,034 paths indexed:

| | |
| --- | --- |
| normal search | 20 results, 164 ms |
| `^(.+)+#$` | **HTTP 503 after 2094 ms** |
| `/api/health` during the attack | 200 in 2.6 ms |
| asset fetch during the attack | 200 in 11 ms |
| search again afterwards | 20 results, 164 ms |

`listFiles()` is memoized as part of this — it rebuilt a Set over every index entry on each call (67 ms for a full data.grf), and search now needs it per request. Identity matters too: the worker keys its cached copy on that array, so a fresh one each call would re-send 9 MB per query. Both caches drop when the index is rebuilt.

Five tests cover it, including one asserting the event loop keeps ticking while a hostile pattern burns.

## 2. The encoding tools never did anything

The five `tools/*.mjs` imported `@chicowall/grf-loader` with `import`, which resolves to its ESM build. That build reaches iconv-lite through a bundler shim needing a global `require`; inside a real `.mjs` there is none, the shim throws, iconv-lite is null, and `isMojibake` / `fixMojibake` / `toMojibake` silently become identity functions.

Two silent consequences:

- **`npm run convert:encoding` could never produce a mapping.** It printed `Mojibake fixed: N` and exited 0 while writing an empty `paths` object. `doctor.js`, `prepare.js` and the README all recommend running it.
- **The validators reported faults that do not exist.** Without iconv the loader falls back to `TextDecoder('euc-kr')`, which does not cover the UHC extension range. Against the real archive, 171,707 names:

  | build | U+FFFD | C1 |
  | --- | --- | --- |
  | ESM (what the tools used) | 4 | 13 |
  | CJS (what the server uses) | **0** | **0** |

  Seventeen phantom encoding errors in an archive the server reads perfectly.

All five now load the package through `createRequire(import.meta.url)`.

**On how this was missed:** this exact report was raised earlier and I dismissed it as a false positive after checking that `fixMojibake` worked. That check ran under `node -e`, which is CommonJS and *does* have a global `require`, so the shim succeeded and the failure never reproduced. `node --input-type=module` shows the opposite. The original report was right.

## 3. Following the README meant never using this server

roBrowserLegacy ships `remoteClient: 'https://grf.robrowser.com/'` as its default (`applications/pwa/Config.js:18`), and that one value decides where every asset comes from — `FileManager.js` concatenates it for single files (`:256`), the batch endpoint (`:340`) and search (`:183`).

Neither README mentioned it. Their `Config.local.js` block covered only `socketProxy`. A user who follows the instructions exactly ends up with a client loading every asset from the public CDN: nothing looks broken, the game runs, and the asset server this repository exists to provide is never touched.

Both READMEs now include it, with a note on why the trailing slash matters, plus a troubleshooting entry for the symptom.

## Verification

`npm test` → 48 pass, 0 fail. Clean `npm install` → exit 0. Every `.js`/`.mjs` passes `node --check`. The ReDoS behaviour was measured over HTTP against a live server with a real archive; the encoding comparison was measured against that same archive with both builds loaded side by side.
